### PR TITLE
return more accurate exit codes on app close

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ python:
   - "3.4"
   - "3.5"
 install:
+  - pip install --upgrade pip
+  - pip --version
+  - pip install --upgrade setuptools
   - pip install tox tox-travis coveralls
 script:
   - tox

--- a/nova/cli/main.py
+++ b/nova/cli/main.py
@@ -63,12 +63,12 @@ class NovaApp(CementApp):
         arg_handler = NovaArgHandler
 
         debug = TOGGLE_DEBUG
-
         exit_on_close = True
 
 
 # Define the application object outside of main, as some libraries might wish
 # to import it as a global (rather than passing it into another class/func)
+
 app = NovaApp()
 
 
@@ -84,14 +84,16 @@ def handle_exception(error):
     if type(error) is FrameworkError:
         # Catch framework errors and exit 1 (error)
         print('FrameworkError > %s' % error)
-        return 1
+        return 2
+    print('Unexpected Error > %s' % error)
+    return 2
 
 
 # noinspection PyBroadException
 def main():
     with app:
         # Default our exit status to 0 (non-error)
-        code = 0
+        exit_code = 0
         try:
             global sys
 
@@ -100,7 +102,7 @@ def main():
 
             app.run()
         except Exception as e:
-            code = handle_exception(e)
+            exit_code = handle_exception(e)
         finally:
             # Print an exception (if it occurred) and --debug was passed
             if app.debug:
@@ -109,13 +111,11 @@ def main():
                     traceback.print_exc()
 
         # Close the application
-        app.close(code)
+        app.close(exit_code)
 
 
 def get_test_app(**kw):
-    app = NovaApp(**kw)
-    return app
-
+    return NovaApp(**kw)
 
 if __name__ == '__main__':
     main()

--- a/nova/cli/main.py
+++ b/nova/cli/main.py
@@ -72,31 +72,35 @@ class NovaApp(CementApp):
 app = NovaApp()
 
 
+def handle_exception(error):
+    if type(error) is exc.NovaError:
+        # Catch our application errors and exit 1 (error)
+        print('NovaError > %s' % error)
+        return 1
+    if type(error) is CaughtSignal:
+        # Default Cement signals are SIGINT and SIGTERM, exit 0 (non-error)
+        print('CaughtSignal > %s' % error)
+        return 0
+    if type(error) is FrameworkError:
+        # Catch framework errors and exit 1 (error)
+        print('FrameworkError > %s' % error)
+        return 1
+
+
+# noinspection PyBroadException
 def main():
     with app:
+        # Default our exit status to 0 (non-error)
+        code = 0
         try:
             global sys
-            # Default our exit status to 0 (non-error)
-            code = 0
 
             # Dump all arguments into nova log
             app.log.debug(sys.argv)
 
             app.run()
-        except exc.NovaError as e:
-            # Catch our application errors and exit 1 (error)
-            print('NovaError > %s' % e)
-            code = 1
-
-        except CaughtSignal as e:
-            # Default Cement signals are SIGINT and SIGTERM, exit 0 (non-error)
-            print('CaughtSignal > %s' % e)
-            code = 0
-
-        except FrameworkError as e:
-            # Catch framework errors and exit 1 (error)
-            print('FrameworkError > %s' % e)
-            code = 1
+        except Exception as e:
+            code = handle_exception(e)
         finally:
             # Print an exception (if it occurred) and --debug was passed
             if app.debug:

--- a/nova/cli/main.py
+++ b/nova/cli/main.py
@@ -64,6 +64,8 @@ class NovaApp(CementApp):
 
         debug = TOGGLE_DEBUG
 
+        exit_on_close = True
+
 
 # Define the application object outside of main, as some libraries might wish
 # to import it as a global (rather than passing it into another class/func)

--- a/nova/core/cfn_pyplates/functions.py
+++ b/nova/core/cfn_pyplates/functions.py
@@ -173,6 +173,7 @@ def join(sep, *args):
 
     return {'Fn::Join': [sep, list(args)]}
 
+
 join._errmsg_needinput = 'Unable to join on one or less things!'
 
 
@@ -216,6 +217,7 @@ def select(index, *args):
         raise IntrinsicFuncInputError(select._errmsg_index)
 
     return {'Fn::Select': [index, list(args)]}
+
 
 select._errmsg_int = 'Index must be a number!'
 select._errmsg_empty = 'Unable to select from an empty list!'
@@ -295,6 +297,8 @@ def c_and(*conditions):
     """
     _validate_logical_condition_counts(c_and, conditions)
     return {'Fn::And': list(conditions)}
+
+
 c_and._errmsg_min = "Minimum umber of conditions for 'c_and' condition is 2"
 c_and._errmsg_max = "Maximum umber of conditions for 'c_and' condition is 10"
 
@@ -315,6 +319,8 @@ def c_or(*conditions):
     """
     _validate_logical_condition_counts(c_or, conditions)
     return {'Fn::Or': list(conditions)}
+
+
 c_or._errmsg_min = "Minimum umber of conditions for 'c_or' condition is 2"
 c_or._errmsg_max = "Maximum umber of conditions for 'c_or' condition is 10"
 

--- a/nova/core/utils/tarfile_progress.py
+++ b/nova/core/utils/tarfile_progress.py
@@ -133,4 +133,5 @@ class FileWrapper(object):
     def __del__(self):
         self._updateprogress(self._size - self._totalread)
 
+
 open = TarFile.open

--- a/tests/cli/deploy/test_deploy.py
+++ b/tests/cli/deploy/test_deploy.py
@@ -12,7 +12,6 @@ except ImportError:
 
 
 class NovaDeployTestCase(NovaTestCase):
-
     def setUp(self):
         self.manager_provider = TestManagerProvider()
         aws_manager_patcher = mock.patch(
@@ -23,39 +22,45 @@ class NovaDeployTestCase(NovaTestCase):
         self.addCleanup(aws_manager_patcher.stop)
 
     def test_deploy_no_args(self):
-        with get_test_app(argv=['deploy']) as app:
-            try:
-                app.run()
-            except NovaError as e:
-                self.assertEqual(e.message, INCORRECT_ARGS_USAGE)
+        with self.assertRaises(SystemExit) as exit_code:
+            with get_test_app(argv=['deploy']) as app:
+                try:
+                    app.run()
+                except NovaError as e:
+                    self.assertEqual(e.message, INCORRECT_ARGS_USAGE)
+        self.assertEqual(exit_code.exception.code, 0)
 
     def test_deploy(self):
-        nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
-        with get_test_app(argv=[
-            'deploy',
-            'test-environment',
-            'test-stack',
-            '--file',
-            nova_descriptor_file
-        ]) as app:
-            app.run()
-        self.manager_provider.mock_aws_manager.create_deployment.assert_called_once_with(
-            'some-deploy-id',
-            'some-deployment-group',
-            mock.ANY,
-            'my-bucket',
-            'test-service/0.0.1.tar.gz'
-        )
+        with self.assertRaises(SystemExit) as exit_code:
+            nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
+            with get_test_app(argv=[
+                'deploy',
+                'test-environment',
+                'test-stack',
+                '--file',
+                nova_descriptor_file
+            ]) as app:
+                app.run()
+            self.manager_provider.mock_aws_manager.create_deployment.assert_called_once_with(
+                'some-deploy-id',
+                'some-deployment-group',
+                mock.ANY,
+                'my-bucket',
+                'test-service/0.0.1.tar.gz'
+            )
+            self.assertEqual(exit_code.exception.code, 0)
 
     def test_no_deploy(self):
-        nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
-        with get_test_app(argv=[
-            'deploy',
-            'test-environment',
-            'test-stack',
-            '--file',
-            nova_descriptor_file,
-            '--no-deployment'
-        ]) as app:
-            app.run()
-        self.manager_provider.mock_aws_manager.create_deployment.assert_not_called()
+        with self.assertRaises(SystemExit) as exit_code:
+            nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
+            with get_test_app(argv=[
+                'deploy',
+                'test-environment',
+                'test-stack',
+                '--file',
+                nova_descriptor_file,
+                '--no-deployment'
+            ]) as app:
+                app.run()
+            self.manager_provider.mock_aws_manager.create_deployment.assert_not_called()
+            self.assertEqual(exit_code.exception.code, 0)

--- a/tests/cli/deploy/test_deploy.py
+++ b/tests/cli/deploy/test_deploy.py
@@ -22,16 +22,15 @@ class NovaDeployTestCase(NovaTestCase):
         self.addCleanup(aws_manager_patcher.stop)
 
     def test_deploy_no_args(self):
-        with self.assertRaises(SystemExit) as exit_code:
+        with self.assertRaises(SystemExit):
             with get_test_app(argv=['deploy']) as app:
                 try:
                     app.run()
                 except NovaError as e:
                     self.assertEqual(e.message, INCORRECT_ARGS_USAGE)
-        self.assertEqual(exit_code.exception.code, 0)
 
     def test_deploy(self):
-        with self.assertRaises(SystemExit) as exit_code:
+        with self.assertRaises(SystemExit):
             nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
             with get_test_app(argv=[
                 'deploy',
@@ -48,10 +47,9 @@ class NovaDeployTestCase(NovaTestCase):
                 'my-bucket',
                 'test-service/0.0.1.tar.gz'
             )
-            self.assertEqual(exit_code.exception.code, 0)
 
     def test_no_deploy(self):
-        with self.assertRaises(SystemExit) as exit_code:
+        with self.assertRaises(SystemExit):
             nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
             with get_test_app(argv=[
                 'deploy',
@@ -63,4 +61,3 @@ class NovaDeployTestCase(NovaTestCase):
             ]) as app:
                 app.run()
             self.manager_provider.mock_aws_manager.create_deployment.assert_not_called()
-            self.assertEqual(exit_code.exception.code, 0)

--- a/tests/cli/exceptions/nova.yml
+++ b/tests/cli/exceptions/nova.yml
@@ -1,0 +1,17 @@
+service_name: test-service
+team_name: nova
+port: 80
+healthcheck_url: /healthcheck
+
+environments:
+  - name: test-environment
+    aws_profile: my-profile
+    aws_region: us-east-1
+    deploy_arn: arn:aws:iam::012345678912:role/my-code-deploy-role
+    deployment_bucket: my-bucket
+    deployment_application_id: some-deploy-id
+    stacks:
+      - stack_name: test-stack
+        stack_type: production
+        stack_deploy_config: OneAtATime
+        deployment_group: some-deployment-group

--- a/tests/cli/exceptions/test_exceptions.py
+++ b/tests/cli/exceptions/test_exceptions.py
@@ -33,7 +33,7 @@ class NovaExceptionHandling(NovaTestCase):
                     code = handle_exception(e)
                 finally:
                     app.close(code)
-        self.assertEqual(exit_code.exception.code, 1)
+            self.assertEqual(exit_code.exception.code, 1)
 
     def test_exit_code_without_error(self):
         self.manager_provider.mock_aws_manager.get_stack.return_value = StackResult("CREATE_COMPLETE")
@@ -57,5 +57,5 @@ class NovaExceptionHandling(NovaTestCase):
                     code = handle_exception(e)
                 finally:
                     app.close(code)
-        self.assertEqual(exit_code.exception.code, 0)
+            self.assertEqual(exit_code.exception.code, 0)
 

--- a/tests/cli/exceptions/test_exceptions.py
+++ b/tests/cli/exceptions/test_exceptions.py
@@ -1,0 +1,61 @@
+import os
+
+from nova.cli.controllers.stack.stack import INCORRECT_UPDATE_ARGS_USAGE
+from nova.cli.main import get_test_app, handle_exception
+from nova.core import NovaError
+from tests.cli.utils import NovaTestCase, TestManagerProvider
+from tests.core import StackResult
+
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
+
+
+class NovaExceptionHandling(NovaTestCase):
+    def setUp(self):
+        self.manager_provider = TestManagerProvider()
+        aws_manager_patcher = mock.patch(
+            'nova.cli.controllers.stack.stack.ManagerProvider',
+            return_value=self.manager_provider
+        )
+        aws_manager_patcher.start()
+        self.addCleanup(aws_manager_patcher.stop)
+
+    def test_exit_code_with_error(self):
+        with self.assertRaises(SystemExit) as exit_code:
+            with get_test_app(argv=['stack', 'update']) as app:
+                code = 0
+                try:
+                    app.run()
+                except NovaError as e:
+                    self.assertEqual(e.message, INCORRECT_UPDATE_ARGS_USAGE)
+                    code = handle_exception(e)
+                finally:
+                    app.close(code)
+        self.assertEqual(exit_code.exception.code, 1)
+
+    def test_exit_code_without_error(self):
+        self.manager_provider.mock_aws_manager.get_stack.return_value = StackResult("CREATE_COMPLETE")
+        nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
+        with self.assertRaises(SystemExit) as exit_code:
+            with get_test_app(argv=[
+                'stack',
+                'create',
+                'test-environment',
+                '--file',
+                nova_descriptor_file
+            ]) as app:
+                code = 0
+                try:
+                    app.run()
+                    self.manager_provider.mock_aws_manager.create_stack.assert_called_with(
+                        'test-service',
+                        mock.ANY
+                    )
+                except Exception as e:
+                    code = handle_exception(e)
+                finally:
+                    app.close(code)
+        self.assertEqual(exit_code.exception.code, 0)
+

--- a/tests/cli/stack/test_stack.py
+++ b/tests/cli/stack/test_stack.py
@@ -23,13 +23,12 @@ class NovaStackTestCase(NovaTestCase):
         self.addCleanup(aws_manager_patcher.stop)
 
     def test_stack_create_no_args(self):
-        with self.assertRaises(SystemExit) as exit_code:
+        with self.assertRaises(SystemExit):
             with get_test_app(argv=['stack', 'create']) as app:
                 try:
                     app.run()
                 except NovaError as e:
                     self.assertEqual(e.message, INCORRECT_CREATE_ARGS_USAGE)
-        self.assertEqual(exit_code.exception.code, 0)
 
     def test_stack_update_no_args(self):
         with self.assertRaises(SystemExit) as exit_code:
@@ -43,7 +42,7 @@ class NovaStackTestCase(NovaTestCase):
     def test_stack_create(self):
         self.manager_provider.mock_aws_manager.get_stack.return_value = StackResult("CREATE_COMPLETE")
         nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
-        with self.assertRaises(SystemExit) as exit_code:
+        with self.assertRaises(SystemExit):
             with get_test_app(argv=[
                 'stack',
                 'create',
@@ -56,12 +55,11 @@ class NovaStackTestCase(NovaTestCase):
                 'test-service',
                 mock.ANY
             )
-        self.assertEqual(exit_code.exception.code, 0)
 
     def test_stack_update(self):
         self.manager_provider.mock_aws_manager.get_stack.return_value = StackResult("UPDATE_COMPLETE")
         nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
-        with self.assertRaises(SystemExit) as exit_code:
+        with self.assertRaises(SystemExit):
             with get_test_app(argv=[
                 'stack',
                 'update',
@@ -76,4 +74,3 @@ class NovaStackTestCase(NovaTestCase):
                 mock.ANY,
                 mock.ANY
             )
-        self.assertEqual(exit_code.exception.code, 0)

--- a/tests/cli/stack/test_stack.py
+++ b/tests/cli/stack/test_stack.py
@@ -13,7 +13,6 @@ except ImportError:
 
 
 class NovaStackTestCase(NovaTestCase):
-
     def setUp(self):
         self.manager_provider = TestManagerProvider()
         aws_manager_patcher = mock.patch(
@@ -24,49 +23,57 @@ class NovaStackTestCase(NovaTestCase):
         self.addCleanup(aws_manager_patcher.stop)
 
     def test_stack_create_no_args(self):
-        with get_test_app(argv=['stack', 'create']) as app:
-            try:
-                app.run()
-            except NovaError as e:
-                self.assertEqual(e.message, INCORRECT_CREATE_ARGS_USAGE)
+        with self.assertRaises(SystemExit) as exit_code:
+            with get_test_app(argv=['stack', 'create']) as app:
+                try:
+                    app.run()
+                except NovaError as e:
+                    self.assertEqual(e.message, INCORRECT_CREATE_ARGS_USAGE)
+        self.assertEqual(exit_code.exception.code, 0)
 
     def test_stack_update_no_args(self):
-        with get_test_app(argv=['stack', 'update']) as app:
-            try:
-                app.run()
-            except NovaError as e:
-                self.assertEqual(e.message, INCORRECT_UPDATE_ARGS_USAGE)
+        with self.assertRaises(SystemExit) as exit_code:
+            with get_test_app(argv=['stack', 'update']) as app:
+                try:
+                    app.run()
+                except NovaError as e:
+                    self.assertEqual(e.message, INCORRECT_UPDATE_ARGS_USAGE)
+        self.assertEqual(exit_code.exception.code, 0)
 
     def test_stack_create(self):
         self.manager_provider.mock_aws_manager.get_stack.return_value = StackResult("CREATE_COMPLETE")
         nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
-        with get_test_app(argv=[
-            'stack',
-            'create',
-            'test-environment',
-            '--file',
-            nova_descriptor_file
-        ]) as app:
-            app.run()
-        self.manager_provider.mock_aws_manager.create_stack.assert_called_with(
-            'test-service',
-            mock.ANY
-        )
+        with self.assertRaises(SystemExit) as exit_code:
+            with get_test_app(argv=[
+                'stack',
+                'create',
+                'test-environment',
+                '--file',
+                nova_descriptor_file
+            ]) as app:
+                app.run()
+            self.manager_provider.mock_aws_manager.create_stack.assert_called_with(
+                'test-service',
+                mock.ANY
+            )
+        self.assertEqual(exit_code.exception.code, 0)
 
     def test_stack_update(self):
         self.manager_provider.mock_aws_manager.get_stack.return_value = StackResult("UPDATE_COMPLETE")
         nova_descriptor_file = '%s/nova.yml' % os.path.dirname(os.path.realpath(__file__))
-        with get_test_app(argv=[
-            'stack',
-            'update',
-            'test-environment',
-            '--file',
-            nova_descriptor_file
-        ]) as app:
-            app.run()
-        self.manager_provider.mock_aws_manager.update_stack.assert_called_with(
-            'test-service',
-            mock.ANY,
-            mock.ANY,
-            mock.ANY
-        )
+        with self.assertRaises(SystemExit) as exit_code:
+            with get_test_app(argv=[
+                'stack',
+                'update',
+                'test-environment',
+                '--file',
+                nova_descriptor_file
+            ]) as app:
+                app.run()
+            self.manager_provider.mock_aws_manager.update_stack.assert_called_with(
+                'test-service',
+                mock.ANY,
+                mock.ANY,
+                mock.ANY
+            )
+        self.assertEqual(exit_code.exception.code, 0)

--- a/tests/cli/stash/test_stash.py
+++ b/tests/cli/stash/test_stash.py
@@ -7,15 +7,20 @@ from tests.cli.utils import NovaTestCase
 class NovaStackTestCase(NovaTestCase):
 
     def test_stash_get(self):
-        with get_test_app(argv=['stash', 'get']) as app:
-            try:
-                app.run()
-            except NovaError as e:
-                self.assertEqual(e.message, INCORRECT_GET_ARGS_USAGE)
+        with self.assertRaises(SystemExit) as exit_code:
+            with get_test_app(argv=['stash', 'get']) as app:
+                try:
+                    app.run()
+                except NovaError as e:
+                    self.assertEqual(e.message, INCORRECT_GET_ARGS_USAGE)
+            self.assertEqual(exit_code.exception.code, 0)
+
 
     def test_stash_put(self):
-        with get_test_app(argv=['stash', 'put']) as app:
-            try:
-                app.run()
-            except NovaError as e:
-                self.assertEqual(e.message, INCORRECT_PUT_ARGS_USAGE)
+        with self.assertRaises(SystemExit) as exit_code:
+            with get_test_app(argv=['stash', 'put']) as app:
+                try:
+                    app.run()
+                except NovaError as e:
+                    self.assertEqual(e.message, INCORRECT_PUT_ARGS_USAGE)
+            self.assertEqual(exit_code.exception.code, 0)

--- a/tests/cli/stash/test_stash.py
+++ b/tests/cli/stash/test_stash.py
@@ -15,7 +15,6 @@ class NovaStackTestCase(NovaTestCase):
                     self.assertEqual(e.message, INCORRECT_GET_ARGS_USAGE)
             self.assertEqual(exit_code.exception.code, 0)
 
-
     def test_stash_put(self):
         with self.assertRaises(SystemExit) as exit_code:
             with get_test_app(argv=['stash', 'put']) as app:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ select = E,W,F,N,I
 [tox]
 envlist=py27,py34,py35,flake8
 
-[tox:travis]
+[travis:python]
 2.7=py27,flake8
 3.4=py34
 3.5=py35,flake8


### PR DESCRIPTION
Currently after a failed stack update nova returns and exit code of 0, this creates a problem for automation 